### PR TITLE
driver_init: load libva-x11.so for any ABI version

### DIFF
--- a/src/media_drv_output_dri.c
+++ b/src/media_drv_output_dri.c
@@ -105,6 +105,15 @@ media_output_dri_init (VADriverContextP ctx)
   struct dri_vtable *dri_vtable;
 
   static const struct dso_symbol symbols[] = {
+#if VA_CHECK_VERSION(1,0,0)
+    {"va_dri_get_drawable",
+     offsetof (struct dri_vtable, get_drawable)},
+    {"va_dri_get_rendering_buffer",
+     offsetof (struct dri_vtable, get_rendering_buffer)},
+    {"va_dri_swap_buffer",
+     offsetof (struct dri_vtable, swap_buffer)},
+    {NULL,}
+#else
     {"dri_get_drawable",
      offsetof (struct dri_vtable, get_drawable)},
     {"dri_get_rendering_buffer",
@@ -112,6 +121,7 @@ media_output_dri_init (VADriverContextP ctx)
     {"dri_swap_buffer",
      offsetof (struct dri_vtable, swap_buffer)},
     {NULL,}
+#endif
   };
 
   drv_ctx->dri_output =

--- a/src/media_drv_output_dri.h
+++ b/src/media_drv_output_dri.h
@@ -30,7 +30,7 @@
 #define _MEDIA__DRIVER_OUT_DRI_H
 #include <stdbool.h>
 #include "media_drv_defines.h"
-#define LIBVA_X11_NAME "libva-x11.so.1"
+#define LIBVA_X11_NAME "libva-x11.so"
 VOID media_output_dri_terminate (VADriverContextP ctx);
 BOOL media_output_dri_init (VADriverContextP ctx);
 


### PR DESCRIPTION
with libva > 2.0.0 hybrid driver can operate with it as well
so make this load generic to libva installed version

Signed-off-by: Daniel Charles <daniel.charles@intel.com>